### PR TITLE
Fix tab number in merge script

### DIFF
--- a/ViennaCCCdb_raw.csv
+++ b/ViennaCCCdb_raw.csv
@@ -1,4 +1,4 @@
-ligand	receptor	ligand_uniprot	receptor_uniprot		database
+ligand	receptor	ligand_uniprot	receptor_uniprot  database
 LGALS9	PTPRC	O00182	P08575	Liana_v0.1.12
 LGALS9	MET	O00182	P08581	Liana_v0.1.12
 LGALS9	CD44	O00182	P16070	Liana_v0.1.12

--- a/scripts/createCombinedDatabase.py
+++ b/scripts/createCombinedDatabase.py
@@ -333,7 +333,7 @@ with open(mihaela_data) as f:
 
 #Print the combined database
 #print("source\ttarget\tsource_genesymbol\ttarget_genesymbol")
-print("ligand\treceptor\tligand_uniprot\treceptor_uniprot\t\tdatabase")
+print("ligand\treceptor\tligand_uniprot\treceptor_uniprot\tdatabase")
 
 for i,inter in enumerate(all_interactions):
     L=inter[0]


### PR DESCRIPTION
This small change removes an extra tab in scripts/createCombinedDatabase.py and updates the raw output file.

This way, when imported back into python, the "database" column gets a name properly.